### PR TITLE
Sunset2018 limit

### DIFF
--- a/provisioning/instance/Makefile
+++ b/provisioning/instance/Makefile
@@ -22,6 +22,9 @@ clean:
 /etc/sysconfig/hakaru: sysconfig/hakaru
 	cp sysconfig/hakaru /etc/sysconfig/hakaru
 
+/etc/secutity/limits.conf: security/limits.conf
+	cp secutity/limits.conf /etc/secutity/limits.conf
+
 /etc/systemd/system/hakaru.service: systemd/hakaru.service /opt/hakaru/bin/hakaru /etc/sysconfig/hakaru
 	cp systemd/hakaru.service /etc/systemd/system/hakaru.service
 	systemctl daemon-reload

--- a/provisioning/instance/Makefile
+++ b/provisioning/instance/Makefile
@@ -22,8 +22,8 @@ clean:
 /etc/sysconfig/hakaru: sysconfig/hakaru
 	cp sysconfig/hakaru /etc/sysconfig/hakaru
 
-/etc/secutity/limits.conf: security/limits.conf
-	cp secutity/limits.conf /etc/secutity/limits.conf
+/etc/security/limits.conf: security/limits.conf
+	cp security/limits.conf /etc/security/limits.conf
 
 /etc/systemd/system/hakaru.service: systemd/hakaru.service /opt/hakaru/bin/hakaru /etc/sysconfig/hakaru
 	cp systemd/hakaru.service /etc/systemd/system/hakaru.service

--- a/provisioning/instance/Makefile
+++ b/provisioning/instance/Makefile
@@ -25,7 +25,7 @@ clean:
 /etc/security/limits.conf: security/limits.conf
 	cp security/limits.conf /etc/security/limits.conf
 
-/etc/systemd/system/hakaru.service: systemd/hakaru.service /opt/hakaru/bin/hakaru /etc/sysconfig/hakaru
+/etc/systemd/system/hakaru.service: systemd/hakaru.service /opt/hakaru/bin/hakaru /etc/sysconfig/hakaru /etc/security/limits.conf
 	cp systemd/hakaru.service /etc/systemd/system/hakaru.service
 	systemctl daemon-reload
 	systemctl list-unit-files --type=service | grep hakaru

--- a/provisioning/instance/security/limits.conf
+++ b/provisioning/instance/security/limits.conf
@@ -1,0 +1,2 @@
+* soft nofile 65536
+* hard nofile 65536

--- a/provisioning/instance/systemd/hakaru.service
+++ b/provisioning/instance/systemd/hakaru.service
@@ -3,6 +3,8 @@ Description=hakaru server
 
 [Service]
 Type=simple
+LimitNOFILE=1006500
+LimitNPROC=1006500
 
 # プロセスが不意に終了した場合の挙動
 # no: 死んだまま always: 自動起動


### PR DESCRIPTION
`Too many open files`のエラーに対応する
具体的にはsessionもファイルディスクリプターなので，それの上限をあげる